### PR TITLE
build(compose): add A11yWatch standalone warp speed accessibility recipe

### DIFF
--- a/docker-compose-services/a11ywatch/README.md
+++ b/docker-compose-services/a11ywatch/README.md
@@ -1,0 +1,27 @@
+# A11yWatch
+
+Using the A11yWatch container image [A11yWatch](https://hub.docker.com/r/a11ywatch/a11ywatch).
+
+Run automated web accessibility audits at warp speed with vast coverage across issues and domains made with Rust.
+
+## Installation
+
+Copy [docker-compose.a11ywatch-standalone.yaml](docker-compose.a11ywatch-standalone.yaml) to your project's .ddev folder.
+
+Optional: adjust env configurations with appropriate keys.
+Optional: set `A11YWATCH_IMAGE` env variable to `darwin` or adjust the image name directly if on mac for improved performance non QEMU.
+
+## Configuration
+
+From within the container, the a11ywatch container is reached at hostname: "a11ywatch", port: 3280 and port: 50050 for gRPC so the server URL might be `http://a11ywatch:3280`. You can also use the "ddev.site" http and https urls to access it: `http://<projectname>.ddev.site:3280`, and `https://<projectname>.ddev.site:3280`
+
+## Connection
+
+You can access the [A11yWatch Lite](https://github.com/a11ywatch/a11ywatch) server directly from the host for debugging purposes by visiting `http://<projectname>.ddev.site:3280`. If you have SSL enabled, which is recommended, you can access A11yWatch via `https://<projectname>.ddev.site:3280`
+
+## Additional Resources
+
+* To get detailed infromation on how to interact or commincate with the [A11yWatch API Info](https://a11ywatch.com/api-info) A11yWatch.
+* The [A11yWatch CLI](https://github.com/a11ywatch/a11ywatch) is helpful to perform automated task using the gRPC client.
+
+**Contributed by [j-mendez](https://github.com/j-mendez) s**

--- a/docker-compose-services/a11ywatch/README.md
+++ b/docker-compose-services/a11ywatch/README.md
@@ -24,4 +24,4 @@ You can access the [A11yWatch Lite](https://github.com/a11ywatch/a11ywatch) serv
 * To get detailed infromation on how to interact or commincate with the [A11yWatch API Info](https://a11ywatch.com/api-info) A11yWatch.
 * The [A11yWatch CLI](https://github.com/a11ywatch/a11ywatch) is helpful to perform automated task using the gRPC client.
 
-**Contributed by [j-mendez](https://github.com/j-mendez) s**
+**Contributed by [j-mendez](https://github.com/j-mendez)**

--- a/docker-compose-services/a11ywatch/docker-compose.a11ywatch-standalone.yaml
+++ b/docker-compose-services/a11ywatch/docker-compose.a11ywatch-standalone.yaml
@@ -1,0 +1,24 @@
+version: '3.6'
+services:
+  a11ywatch:
+    container_name: ddev-${DDEV_SITENAME}-a11ywatch
+    hostname: ${DDEV_SITENAME}-a11ywatch
+    image: a11ywatch/a11ywatch:${A11YWATCH_IMAGE:-latest}
+    expose:
+      - "3280"
+      - "50050"
+    environment:
+      - COMPUTER_VISION_ENDPOINT=${COMPUTER_VISION_ENDPOINT:-""}
+      - COMPUTER_VISION_SUBSCRIPTION_KEY=${COMPUTER_VISION_SUBSCRIPTION_KEY:-""}
+      - PAGESPEED_API_KEY=${PAGESPEED_API_KEY:-""}
+      - AI_DISABLED=${AI_DISABLED:-false}
+      - SUPER_MODE=${SUPER_MODE:-true}
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    volumes:
+      - a11ywatch:/usr/share/a11ywatch/data
+      - ".:/mnt/ddev_config"
+
+volumes:
+  a11ywatch:

--- a/docker-compose-services/a11ywatch/docker-compose.a11ywatch-standalone.yaml
+++ b/docker-compose-services/a11ywatch/docker-compose.a11ywatch-standalone.yaml
@@ -1,24 +1,26 @@
 version: '3.6'
+
 services:
   a11ywatch:
     container_name: ddev-${DDEV_SITENAME}-a11ywatch
     hostname: ${DDEV_SITENAME}-a11ywatch
     image: a11ywatch/a11ywatch:${A11YWATCH_IMAGE:-latest}
+    networks: [default, ddev_default]
     expose:
-      - "3280"
-      - "50050"
+      - 3280
+      - 50050
+    ports:
+      - 3280:3280
+      - 50050:50050
     environment:
       - COMPUTER_VISION_ENDPOINT=${COMPUTER_VISION_ENDPOINT:-""}
       - COMPUTER_VISION_SUBSCRIPTION_KEY=${COMPUTER_VISION_SUBSCRIPTION_KEY:-""}
       - PAGESPEED_API_KEY=${PAGESPEED_API_KEY:-""}
       - AI_DISABLED=${AI_DISABLED:-false}
       - SUPER_MODE=${SUPER_MODE:-true}
+
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
     volumes:
-      - a11ywatch:/usr/share/a11ywatch/data
       - ".:/mnt/ddev_config"
-
-volumes:
-  a11ywatch:


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:

The most efficient web accessibility tool that covers the most issues and domain reach(subdomains, TLDs, etc).
Can run millions of audits within minutes depending on the pages being audited (SSG|SSR).

## How this PR Solves The Problem:

Quick startup recipe that allows the community to get the most dynamic accessibility testing with flexibility.
Can handle large websites in seconds to minutes including more accessibility coverage on the issues being able to detect by over 23% the best alternative.

## Manual Testing Instructions:

If curl is installed you can perform a quick test over REST/OpenAPI

```
curl --location --request POST 'http://a11ywatch:3280/api/crawl' \                        
--header 'Transfer-Encoding: chunked' \
--header 'Content-Type: application/json' \
--data-raw '{
    "url": "https://a11ywatch.com",
    "subdomains": false,
    "tld": false,
    "robots": false,
    "sitemap": false
}' > results.json
```

## Related Issue Link(s):

Standalone build is compact and very portable. The micro-service setup may be of use later too.