### PR TITLE
feat ref #223: fixes the error installing sqlsrv

### DIFF
--- a/docker-compose-services/sqlsrv/Dockerfile
+++ b/docker-compose-services/sqlsrv/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
+ARG odbc_version=2.3.7
 
 ENV PATH="${PATH}:/opt/mssql-tools/bin"
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests apt-utils curl gnupg2 ca-certificates
@@ -8,16 +7,25 @@ RUN curl -sSL -O https://packages.microsoft.com/keys/microsoft.asc
 RUN apt-key add <microsoft.asc
 RUN curl -sSL -o /etc/apt/sources.list.d/mssql-release.list https://packages.microsoft.com/config/debian/11/prod.list
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests build-essential dialog php-pear php-dev unixodbc-dev locales
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests \
+    build-essential \
+    dialog \
+    php-pear \
+    php$DDEV_PHP_VERSION-dev \
+    unixodbc=$odbc_version \
+    odbcinst=$odbc_version \
+    odbcinst1debian2=$odbc_version \
+    unixodbc-dev=$odbc_version \
+    locales
 
 RUN ACCEPT_EULA=Y DEBIAN_FRONTEND=noninteractive apt-get install -y msodbcsql18 mssql-tools
 
 # Change the PHP version to what you want. It is currently set to version 8.0.
 RUN pecl channel-update pecl.php.net
-RUN pecl -d php_suffix=8.0 install sqlsrv
-RUN pecl -d php_suffix=8.0 install pdo_sqlsrv
+RUN pecl -d php_suffix=$DDEV_PHP_VERSION install sqlsrv
+RUN pecl -d php_suffix=$DDEV_PHP_VERSION install pdo_sqlsrv
 
-RUN echo 'extension=sqlsrv.so' >> "/etc/php/8.0/mods-available/sqlsrv.ini"
-RUN echo 'extension=pdo_sqlsrv.so' >> "/etc/php/8.0/mods-available/pdo_sqlsrv.ini"
+RUN echo 'extension=sqlsrv.so' >> /etc/php/$DDEV_PHP_VERSION/mods-available/sqlsrv.ini
+RUN echo 'extension=pdo_sqlsrv.so' >> /etc/php/$DDEV_PHP_VERSION/mods-available/pdo_sqlsrv.ini
 
-RUN phpenmod sqlsrv pdo_sqlsrv
+RUN phpenmod -v $DDEV_PHP_VERSION sqlsrv pdo_sqlsrv


### PR DESCRIPTION
* uses odbc version 2.3.7
* parameterizes PHP version

<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:
Using the previous Dockerfile I get the following error
```
❯ ddev debug refresh
failed to solve: executor failed running [/bin/sh -c pecl -d php_suffix=8.1 install sqlsrv]: exit code: 1
...
...
...
#22 18.22 /bin/sed: can't read /usr/lib/x86_64-linux-gnu/libltdl.la: No such file or directory
#22 18.22 libtool:   error: '/usr/lib/x86_64-linux-gnu/libltdl.la' is not a valid libtool archive
#22 18.22 make: *** [Makefile:250: sqlsrv.la] Error 1
#22 18.23 ERROR: `make' failed
...
...
```
It seems something related to version 2.3.11 of unixodbc.

## How this PR Solves The Problem:
Forcing the unixodbc version 2.3.7

## Manual Testing Instructions:

1. Copy the `Dockerfile` in `.ddev/web-build/`
2. run `ddev php --info | grep pdo_sqlsrv`

You should get 
```
/etc/php/8.1/cli/conf.d/20-pdo_sqlsrv.ini,
pdo_sqlsrv
pdo_sqlsrv support => enabled
pdo_sqlsrv.client_buffer_max_kb_size => 10240 => 10240
pdo_sqlsrv.log_severity => 0 => 0
pdo_sqlsrv.report_additional_errors => 1 => 1
pdo_sqlsrv.set_locale_info => 2 => 2
```

## Related Issue Link(s):

