### PR TITLE
Add Silverstripe sake

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ DDEV's [custom commands](https://ddev.readthedocs.io/en/latest/users/extend/cust
 * [Stop all running projects except the current](custom-commands/stop-other)
 * [Dynamically enable / disable a service](custom-commands/dynamic-service)
 * [Automatically open browser and login to Drupal](custom-commands/drupal-login)
+* [Run Silverstripe frameworks command directly](custom-commands/silverstripe)
 
 ## Additional services added via docker-compose.\<service\>.yaml
 

--- a/custom-commands/silverstripe/README.md
+++ b/custom-commands/silverstripe/README.md
@@ -1,0 +1,11 @@
+# Silverstripe "sake" command
+
+Copy the sake file to either your project's `.ddev/commands/web` folder. Or, for global usage, copy it to `{YOUR_HOME_FOLDER}/.ddev/commands/web`
+
+## Usage
+
+Sake is the Silverstripe Make command, to run development tools.
+
+Use it as sake in your project:
+
+`ddev sake dev/tasks`

--- a/custom-commands/silverstripe/README.md
+++ b/custom-commands/silverstripe/README.md
@@ -8,4 +8,10 @@ Sake is the Silverstripe Make command, to run development tools.
 
 Use it as sake in your project:
 
-`ddev sake dev/tasks`
+`ddev sake dev/tasks` for tasks
+
+`ddev sake dev/build` to build the database
+
+etc.
+
+For the full list of features of Silverstripe CLI, see the Silverstripe (developer) documentation.

--- a/custom-commands/silverstripe/sake
+++ b/custom-commands/silverstripe/sake
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-vendor/bin/sake $@
+## Description: Run Silverstripe make
+## Usage: sake <command-url> <parameters>
+## Example: "ddev sake dev/tasks" or "ddev sake dev/build flush=all"
+## ExecRaw: true
+## HostWorkingDir: true
+
+sake $@

--- a/custom-commands/silverstripe/sake
+++ b/custom-commands/silverstripe/sake
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+vendor/bin/sake $@


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:

Add Silverstripe sake to remove the need to fully type out `ddev exec vendor/bin/sake {task}`

## How this PR Solves The Problem:

With this addition, one can easily install the sake proxy, and run `ddev sake {task}`

## Manual Testing Instructions:

Run the commands described above.


