### PR TITLE
Update README and Standalone to use solr1

### DIFF
--- a/docker-compose-services/solr/README.md
+++ b/docker-compose-services/solr/README.md
@@ -34,7 +34,7 @@ development environment is to just stay with the default.
 Once up and running you can access Solr's UI within your browser by opening
 `http://<projectname>.ddev.site:8983`. For example, if the project is named
 "myproject" the hostname will be `http://myproject.ddev.site:8983`. To access
-the Solr container from the web container use `ddev-<project>-solr:8983`.
+the Solr container from the web container use `ddev-<project>-solr1:8983`.
 
 Solr Cloud depends on Zookeeper to share configurations between the Solr nodes.
 Therefore this service starts a single Zookeeper server on port 2181, too. It is
@@ -62,6 +62,8 @@ details page, or automate things using
 ddev drush search-api-solr:upload-configset SERVER_ID NUMBER_OF_SHARDS
 ```
 
+`SERVER_ID` is the Search API server machine name. 
+
 Note: If you choose to run Solr Cloud using a single node in standalone mode,
       you need to limit the number of "shards" to "1" when uploading the
       configset. There's a corresponding option in the UI and a parameter for
@@ -71,7 +73,7 @@ Note: If you choose to run Solr Cloud using a single node in standalone mode,
 
 1. Copy `docker-compose.solr.yaml` **or** `docker-compose.solr-standalone.yaml` to your project's `.ddev` directory.
 2. Copy the `solr` folder (`including security.json`) to your project's `.ddev` directory.
-3. Configure your application to connect Solr at `http://ddev-<project>-solr:8983`.
+3. Configure your application to connect Solr at `http://ddev-<project>-solr1:8983`.
 4. If you want to use Solr's APIs that require a trusted context configure Basic Auth with username `solr` and password `SolrRocks`.
 5. (Re-)start your DDEV project.
 
@@ -93,7 +95,7 @@ $config = [
     'endpoint' => [
         'localhost' => [
             // Replace <project> by your project's name:
-            'host' => 'ddev-<project>-solr',
+            'host' => 'ddev-<project>-solr1',
             'port' => 8983,
             'path' => '/',
             // Use your collection name here:
@@ -112,7 +114,7 @@ $client = new Solarium\Client($adapter, $eventDispatcher, $config);
 * Enable the `search_api_solr_admin` module. (This sub-module is included in Search API Solr >= 4.2.1)
 * Create a search server using the Solr backend and select `Solr Cloud with Basic Auth` as connector:
   * HTTP protocol: `http`
-  * Solr node: `ddev-<project>-solr` (Replace <project> by your project's name.)
+  * Solr node: `ddev-<project>-solr1` (Replace <project> by your project's name.)
   * Solr port: `8983`
   * Solr path: `/`
   * Default Solr collection: `techproducts` (You can define any name here. The collection will be created automatically.)

--- a/docker-compose-services/solr/docker-compose.solr-standalone.yaml
+++ b/docker-compose-services/solr/docker-compose.solr-standalone.yaml
@@ -75,8 +75,8 @@ services:
   # access the Solr service at http://solr:8983
   web:
     links:
-      - solr:solr
+      - solr1:solr
 
 volumes:
-  solr:
+  solr1:
   zoo:

--- a/docker-compose-services/solr/docker-compose.solr-standalone.yaml
+++ b/docker-compose-services/solr/docker-compose.solr-standalone.yaml
@@ -10,7 +10,7 @@
 #   For example, if the project is named "myproject" the hostname will be:
 #   http://myproject.ddev.site:8983
 # - To access the Solr container from the web container use:
-#   ddev-<project>-solr:8983
+#   ddev-<project>-solr1:8983
 #
 # To use this in your own project:
 # 1. Copy this file and the solr (including security.json) directory to your project's ".ddev" directory.
@@ -18,6 +18,7 @@
 #      - enable the search_api_solr_admin (this sub-module included in Search API Solr >= 4.2.1)
 #      - create a search server using the Solr Cloud Connector with Basic Auth using username "solr" and password
 #        "SolrRocks".
+#      - remember to fill out "Default Solr collection" field
 #      - press the "Upload Configset" button.
 #      - select the checkbox "Upload (and overwrite) configset to Solr Server."
 #      - set the number of shards to "1" and press "Upload"

--- a/docker-compose-services/solr/docker-compose.solr-standalone.yaml
+++ b/docker-compose-services/solr/docker-compose.solr-standalone.yaml
@@ -24,9 +24,9 @@
 
 version: '3.6'
 services:
-  solr:
+  solr1:
     image: solr:8
-    container_name: ddev-${DDEV_SITENAME}-solr
+    container_name: ddev-${DDEV_SITENAME}-solr1
     expose:
       - 8983
     # These labels ensure this service is discoverable by ddev.
@@ -34,7 +34,7 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
     environment:
-      SOLR_HOST: ddev-${DDEV_SITENAME}-solr
+      SOLR_HOST: ddev-${DDEV_SITENAME}-solr1
       SOLR_PORT: 8983
       # The pre-trained OpenNLP models require a much bigger buffer.
       SOLR_OPTS: -Djute.maxbuffer=50000000
@@ -46,7 +46,7 @@ services:
       - zoo
     volumes:
       - .:/mnt/ddev_config
-      - solr:/var/solr
+      - solr1:/var/solr
     command: bash -c "docker-entrypoint.sh solr zk cp file:/mnt/ddev_config/solr/security.json zk:/security.json && exec solr-foreground"
 
   zoo:

--- a/docker-compose-services/solr/docker-compose.solr.yaml
+++ b/docker-compose-services/solr/docker-compose.solr.yaml
@@ -6,7 +6,7 @@
 #   For example, if the project is named "myproject" the hostname will be:
 #   http://myproject.ddev.site:8983
 # - To access the Solr container from the web container use:
-#   ddev-<project>-solr:8983
+#   ddev-<project>-solr1:8983
 #
 # To use this in your own project:
 # 1. Copy this file and the solr (including security.json) directory to your project's ".ddev" directory.
@@ -14,6 +14,7 @@
 #      - enable the search_api_solr_admin (this sub-module included in Search API Solr >= 4.2.1)
 #      - create a search server using the Solr Cloud Connector with Basic Auth using username "solr" and password
 #        "SolrRocks".
+#      - remember to fill out "Default Solr collection" field
 #      - press the "Upload Configset" button.
 
 version: '3.6'


### PR DESCRIPTION
Solves 
* #221

## The Problem:

The [Apache Solr (Cloud) Integration for DDEV-Local README](https://github.com/ddev/ddev-contrib/tree/master/docker-compose-services/solr) file uses `ddev-<project>-solr` where `ddev-<project>-solr1` should be used.

## How this PR Solves The Problem:

- Updates the [docker-compose.solr-standalone.yaml](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/solr/docker-compose.solr-standalone.yaml) file to use `solr1`
- Updates the README to use `ddev-<project>-solr1`

## Remaining tasks

- [ ] Check if the README instructions are clear
- [ ] Test the Standalone solution thoroughly

## Manual Testing Instructions:

## Related Issue Link(s):

drupal.org issue: https://www.drupal.org/project/search_api_solr/issues/3365826

