### PR TITLE
Remove ext-intl PHP note, since it is included

### DIFF
--- a/recipes/civicrm/README.md
+++ b/recipes/civicrm/README.md
@@ -16,9 +16,7 @@ See https://docs.civicrm.org/installation/en/latest/drupal/. Other CMS'es, such 
 
 For Drupal 10, download CiviCRM with this command. Study the guide above for details:
 
-`ddev composer require civicrm/civicrm-{core,packages,drupal-8} --ignore-platform-req=ext-intl`
-
-*ToDo*: Add command to add `ext-intl` PHP extension in DDEV.
+`ddev composer require civicrm/civicrm-{core,packages,drupal-8}`
 
 
 ## Import separate CiviCRM database, configure database and template settings


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:

The `ext-intl` PHP extension is included in DDEV, so removing this note.

## How this PR Solves The Problem:

## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->

## Related Issue Link(s):

