### PR TITLE
Update Dockerfile for newest version of stripe-cli

### DIFF
--- a/web-container-dockerfiles/stripe-cli/Dockerfile
+++ b/web-container-dockerfiles/stripe-cli/Dockerfile
@@ -5,7 +5,6 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-RUN apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys 379CE192D401AB61
-RUN echo "deb https://dl.bintray.com/stripe/stripe-cli-deb stable main" | sudo tee -a /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get install stripe
+RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
+RUN sudo apt update && apt install stripe

--- a/web-container-dockerfiles/stripe-cli/README.md
+++ b/web-container-dockerfiles/stripe-cli/README.md
@@ -16,7 +16,7 @@ ddev exec stripe --version
 should output something like this
 
 ```bash
-stripe version 1.5.1
+stripe version 1.18.0
 ```
 
 Well done. Now you can start to listen to the stripe web hooks. Have fun 🎉


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:
Update Dockerfile to be able to install the newest version of Stripe CLI

## How this PR Solves The Problem:
With the old Dockerfile, it was not possible to install the newest version of Stripe CLI

## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->
See `web-container-dockerfiles/stripe-cli/README.md` file

## Related Issue Link(s):
https://github.com/ddev/ddev-contrib/pull/86
