### PR TITLE
Make PHP Version Dynamic

### DIFF
--- a/web-container-dockerfiles/grpc/Dockerfile
+++ b/web-container-dockerfiles/grpc/Dockerfile
@@ -1,12 +1,12 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-ENV PHP_VERSION=7.4
+ENV PHP_VERSION=$DDEV_PHP_VERSION
 RUN \
     apt-get update && apt-get install -y libz-dev php-dev php-pear && \
     pecl install grpc && \
     pecl install protobuf && \
-    echo "extension=grpc.so" > /etc/php/7.4/cli/conf.d/grpc.ini && \
-    echo "extension=protobuf.so" > /etc/php/7.4/cli/conf.d/protobuf.ini  && \
-    echo "extension=grpc.so" > /etc/php/7.4/fpm/conf.d/grpc.ini  && \
-    echo "extension=protobuf.so" > /etc/php/7.4/fpm/conf.d/protobuf.ini
+    echo "extension=grpc.so" > /etc/php/$DDEV_PHP_VERSION/cli/conf.d/grpc.ini && \
+    echo "extension=protobuf.so" > /etc/php/$DDEV_PHP_VERSION/cli/conf.d/protobuf.ini  && \
+    echo "extension=grpc.so" > /etc/php/$DDEV_PHP_VERSION/fpm/conf.d/grpc.ini  && \
+    echo "extension=protobuf.so" > /etc/php/$DDEV_PHP_VERSION/fpm/conf.d/protobuf.ini


### PR DESCRIPTION
Use $DDEV_PHP_VERSION to update the correct version.

## The New Solution/Problem/Issue/Bug:
instead of hardcoded php version number use $DDEV_PHP_VERSION variable to make this dynamic.

## How this PR Solves The Problem:
that there is no fixed 7.4 in the files so  the solution is better managable if projects evolve. 

## Manual Testing Instructions:
`ddev up`  wait for the grpc / protobuf build to complete and check that the extensions are installed `ddev exec php -m | grep -i 'grpc\|protobuf'`


