### PR TITLE
Updated Ports - Changed from ports to expose (docker-compose.chrome.yaml)

### DIFF
--- a/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
+++ b/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
@@ -6,7 +6,7 @@ services:
         container_name: ddev-${DDEV_SITENAME}-chrome
         labels:
             com.ddev.site-name: ${DDEV_SITENAME}
-            com.ddev.approot: $DDEV_APPROOT
+            com.ddev.approot: ${DDEV_APPROOT}
         volumes:
             - ddev-global-cache:/mnt/ddev-global-cache
             - ".:/mnt/ddev_config"
@@ -14,7 +14,9 @@ services:
             - "ddev-router:${DDEV_HOSTNAME}"
         cap_add:
             - SYS_ADMIN
-        ports:
-        # Exposing this port allows you to visit 127.0.0.1:9222 to see what Headless Chrome doing without
-        # any additional configuration; However, you can only have one project using this port at a time.
-            - '9222:9222'
+        expose:
+            - "9222"
+        environment:
+            - VIRTUAL_HOST=$DDEV_HOSTNAME
+            - HTTP_EXPOSE=9221:9222
+            - HTTPS_EXPOSE=9222:9222


### PR DESCRIPTION
Changed 'ports' to 'expose'. Ports exposed to the other services but not to the host machine.

That approach usually isn’t sustainable because two projects might want to use the same port, so we expose the additional port to the Docker network and then use ddev-router to bind it to the host. This works only for services with an HTTP API, but results in having both HTTP and HTTPS ports (9998 and 9999).

https://ddev.readthedocs.io/en/latest/users/extend/custom-compose-files/#docker-composeyaml-examples