### PR TITLE
fix: do not fail on `apt-get update`, cleanup

### DIFF
--- a/docker-compose-services/php8_2/php-build/Dockerfile
+++ b/docker-compose-services/php8_2/php-build/Dockerfile
@@ -1,9 +1,7 @@
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
-ENV PHP_EXTENSIONS="curl fileinfo gd pdo_mysql"
+ARG PHP_EXTENSIONS="curl fileinfo gd pdo_mysql"
 SHELL ["bash", "-c"]
 
-RUN apt-get update -qq && apt-get install -y -qq build-essential less libpng-dev netcat procps telnet vim zlib1g-dev
+RUN (apt-get update || true) && apt-get install -y -qq build-essential less libpng-dev netcat procps telnet vim zlib1g-dev
 RUN set -eu -o pipefail && for extension in ${PHP_EXTENSIONS}; do \
   docker-php-ext-configure ${extension} && docker-php-ext-install ${extension}; \
   done

--- a/docker-compose-services/sqlsrv/Dockerfile
+++ b/docker-compose-services/sqlsrv/Dockerfile
@@ -1,14 +1,11 @@
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
-
 ENV PATH="${PATH}:/opt/mssql-tools/bin"
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests apt-utils curl gnupg2 ca-certificates
+RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests apt-utils curl gnupg2 ca-certificates
 
 RUN curl -sSL -O https://packages.microsoft.com/keys/microsoft.asc
 RUN apt-key add <microsoft.asc
 RUN curl -sSL -o /etc/apt/sources.list.d/mssql-release.list https://packages.microsoft.com/config/debian/11/prod.list
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests build-essential dialog php-pear php-dev unixodbc-dev locales
+RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests build-essential dialog php-pear php-dev unixodbc-dev locales
 
 RUN ACCEPT_EULA=Y DEBIAN_FRONTEND=noninteractive apt-get install -y msodbcsql18 mssql-tools
 

--- a/recipes/laravel-horizon/dot.ddev/web-build/Dockerfile
+++ b/recipes/laravel-horizon/dot.ddev/web-build/Dockerfile
@@ -1,5 +1,2 @@
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
-
 # Add horizon supervisor
 ADD horizon.conf /etc/supervisor/conf.d

--- a/recipes/proxy/Dockerfile
+++ b/recipes/proxy/Dockerfile
@@ -1,8 +1,6 @@
 # This is a Dockerfile for use with the ddev-webserver image
 # It should be in .ddev/web-build/Dockerfile
 # and then you can expand on it.
-ARG BASE_IMAGE=drud/ddev-webserver:v1.9.1
-FROM $BASE_IMAGE
 # If HTTP_PROXY is set in the docker environment, then add the same proxy configuration
 # into apt system in the Debian-based ddev-webserver image at
 # /etc/apt/apt.conf.d/proxy.conf

--- a/web-container-dockerfiles/grpc/Dockerfile
+++ b/web-container-dockerfiles/grpc/Dockerfile
@@ -1,9 +1,6 @@
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
-
 ENV PHP_VERSION=$DDEV_PHP_VERSION
 RUN \
-    apt-get update && apt-get install -y libz-dev php-dev php-pear && \
+    (apt-get update || true) && apt-get install -y libz-dev php-dev php-pear && \
     pecl install grpc && \
     pecl install protobuf && \
     echo "extension=grpc.so" > /etc/php/$DDEV_PHP_VERSION/cli/conf.d/grpc.ini && \

--- a/web-container-dockerfiles/laravel-queue-worker/Dockerfile
+++ b/web-container-dockerfiles/laravel-queue-worker/Dockerfile
@@ -1,4 +1,2 @@
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
 ADD laravel-worker.conf /etc/supervisor/conf.d/
 

--- a/web-container-dockerfiles/stripe-cli/Dockerfile
+++ b/web-container-dockerfiles/stripe-cli/Dockerfile
@@ -1,10 +1,6 @@
 
 # Install the Stripe CLI
 # Documentation: https://stripe.com/docs/stripe-cli#install
-
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
-
 RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
-RUN sudo apt update && apt install stripe
+RUN (apt update || true) && apt install stripe


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/5623

We must not allow apt-get update to fail if some repository is down, because it can stop the webserver from starting.

## How This PR Solves The Issue

Allows `apt-get install` to continue after a fail for `apt-get update`.

Removes:
```
ARG BASE_IMAGE
FROM $BASE_IMAGE
```

Replaces some `ENV` with `ARG`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

