### PR TITLE
Update chromedriver service and instructions to match latest Drupal 11 latest

### DIFF
--- a/docker-compose-services/drupalci-chromedriver/README.md
+++ b/docker-compose-services/drupalci-chromedriver/README.md
@@ -14,21 +14,21 @@ It is based on [Matt Glaman's excelent blog post](https://glamanate.com/blog/run
 
 * Copy `docker-compose.chromedriver.yaml` to the `.ddev` folder of your project.
 * Set environment variables in the "environment" section of the "web" service in `docker-compose.chromedriver.yaml` as appropriate. The defaults are for Drupal Functional and FunctionalJavascript testing.
-* Verify that your phpunit.xml does not define `MINK_DRIVER_ARGS_WEBDRIVER`. This should come from our docker-compose.chromedriver.yaml.
+* Verify that your phpunit.xml does not define `MINK_DRIVER_ARGS_WEBDRIVER`, `SIMPLETEST_DB`, `SIMPLETEST_BASE_URL`, `BROWSERTEST_OUTPUT_DIRECTORY`, or `BROWSERTEST_OUTPUT_BASE_URL`. These should come from our docker-compose.chromedriver.yaml.
 * Ensure that one of the two `SIMPLETEST_DB` options is uncommented.
 * Start (or restart) DDEV to have the service initialized: `ddev start`
 * Your Drupal project must be built with --require-dev to get necessary dependencies like phpunit (for example, `ddev composer create drupal/recommended-project --require-dev`)
 * To test the setup, `ddev ssh` and run a Drupal unit test that triggers ChromeDriver. Example (assumes Drupal core is in the `web` directory):
 
 ```bash
-user@demo-web:/var/www/html$ phpunit --verbose -c web/core/phpunit.xml.dist web/core/modules/system/tests/src/FunctionalJavascript/System/DateFormatTest.php
+user@demo-web:/var/www/html$ phpunit -c web/core/phpunit.xml.dist web/core/modules/system/tests/src/FunctionalJavascript/System/DateFormatTest.php
 ```
 ## Example run
 
 From @damienmckenna, here's an example run to demonstrate functionality:
 
 ```bash
-$ ddev exec phpunit --verbose -c core/phpunit.xml.dist core/modules/system/tests/src/FunctionalJavascript/System/DateFormatTest.php
+$ ddev exec phpunit -c core/phpunit.xml.dist core/modules/system/tests/src/FunctionalJavascript/System/DateFormatTest.php
 PHPUnit 8.5.8 by Sebastian Bergmann and contributors.
 
 Runtime:       PHP 7.3.27-9+0~20210227.82+debian10~1.gbpa4a3d6

--- a/docker-compose-services/drupalci-chromedriver/README.md
+++ b/docker-compose-services/drupalci-chromedriver/README.md
@@ -1,10 +1,10 @@
-# DrupalCI ChromeDriver (Behat, DrupalCI, FunctionalJavascript)
+# [Obsolete] DrupalCI ChromeDriver (Behat, DrupalCI, FunctionalJavascript)
 
-**Note: You may want to take a look at the [ddev-selenium-standalone-chrome add-on](https://github.com/weitzman/ddev-selenium-standalone-chrome) for this situation.**
+**The recommended approach for running tests that require ChromeDriver is to use [ddev-selenium-standalone-chrome add-on](https://github.com/ddev/ddev-selenium-standalone-chrome) instead.**
 
 This recipe adds the DrupalCI ChromeDriver container to a project.
 
-**Note that the drupalci Chromedriver does not work on macOS M1 computers.**
+**Note that the drupalci Chromedriver does not work on Apple Silicon computers, see the Selenium Standalone Chrome note above.**
 
 Among other things, this supports Drupal's FunctionalJavascript tests.
 But it also supports Behat with WebDriver or any other use of headless Chrome.

--- a/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
+++ b/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
@@ -2,7 +2,6 @@
 # There is one item that must be configured in this file in order for it to
 # work, please see below.
 
-version: '3.6'
 services:
   chromedriver:
     image:  drupalci/webdriver-chromedriver:production
@@ -21,10 +20,10 @@ services:
       # In order for the system to work, one of these must be uncommented so
       # that the test system can connect to the database.
       # - SIMPLETEST_DB=sqlite://tmp/test.sqlite
-      # - SIMPLETEST_DB=mysql://ddev-<project>-db:db@db:3306/db
+      # - SIMPLETEST_DB=mysql://db:db@db/db
       #
       # Note: Do not modify the base URL value.
       - SIMPLETEST_BASE_URL=http://web
       - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
       - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
-      - MINK_DRIVER_ARGS_WEBDRIVER=["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chromedriver:9515"]
+      - MINK_DRIVER_ARGS_WEBDRIVER=["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chromedriver:9515"]


### PR DESCRIPTION
Thanks for this very helpful chromedriver docker compose and detailed instructions, has been very helpful as a reference!

## The New Solution/Problem/Issue/Bug:

- The default sample chromedriver docker compose file has some issues:
  - The mysql connection sample does not work as is
  - chromeOptions is deprecated and should be goog:chromeOptions
  - adding version is deprecated
- The README is missing some instructions
  - It specifies only leaving the mink args unchanged, but actually the sample docker compose provides more values than that

## How this PR Solves The Problem:

- Updates docker compose file to fix the above
- Updates the README to fix the above